### PR TITLE
Migrate to cnfast for className merging

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { cn } from "cnfast";
 import { Github, Twitter, FileText } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { cn } from "cnfast";
 import * as React from "react";
 
 function Avatar({

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@/lib/utils";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cnfast";
 import * as React from "react";
 
 const badgeVariants = cva(

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@/lib/utils";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cnfast";
 import * as React from "react";
 
 const buttonVariants = cva(

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "cnfast";
 import * as React from "react";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import { cn } from "cnfast";
 import * as React from "react";
 
 function Separator({

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "cnfast";
 import * as React from "react";
 
 const Table = React.forwardRef<

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,0 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { cn } from "@/lib/utils";
+import { cn } from "cnfast";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cspalevic-web",
+  "name": "migrate-cnfast",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -16,7 +16,7 @@
         "@vercel/analytics": "^1.1.1",
         "@vercel/speed-insights": "^1.0.3",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
+        "cnfast": "^0.0.8",
         "lucide-react": "^0.539.0",
         "next": "^16.2.9",
         "react": "^19.2.7",
@@ -24,7 +24,6 @@
         "rehype-shiki": "^0.0.9",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
-        "tailwind-merge": "^3.3.1",
         "three": "^0.179.1",
         "yet-another-react-lightbox": "^3.21.6",
         "zod": "^4.0.17"
@@ -4644,6 +4643,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cnfast": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cnfast/-/cnfast-0.0.8.tgz",
+      "integrity": "sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==",
+      "license": "MIT",
+      "bin": {
+        "cnfast": "bin/cli.js"
       }
     },
     "node_modules/collapse-white-space": {
@@ -10766,16 +10774,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
-      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@vercel/analytics": "^1.1.1",
     "@vercel/speed-insights": "^1.0.3",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "lucide-react": "^0.539.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
@@ -31,7 +31,6 @@
     "rehype-shiki": "^0.0.9",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.1",
     "three": "^0.179.1",
     "yet-another-react-lightbox": "^3.21.6",
     "zod": "^4.0.17"

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 Chavo
+cnfast
 Frontmatter
 Innov8tek
 johnbielskilaw


### PR DESCRIPTION
## Summary

Migrates className merging from the `clsx` + `tailwind-merge` based `cn` helper to [cnfast](https://github.com/aidenybai/cnfast), a faster drop-in replacement with byte-identical output.

## Changes

- Add `cnfast` dependency
- Remove `clsx`, `tailwind-merge`, and the local `lib/utils.ts` file
- Update all `import { cn } from "@/lib/utils"` → `import { cn } from "cnfast"` (8 files)

## Validation

- `npm run check:types` ✅
- `npm run lint` ✅
- `npm run check:formatting` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)